### PR TITLE
Automate configuration of sshfs

### DIFF
--- a/docs/configure-sshfs.sh
+++ b/docs/configure-sshfs.sh
@@ -16,7 +16,8 @@ gid=$(id -g)
 # Assume current context is set to Springfield.
 context="$(kubectl config current-context)"
 
-# Find namespace via our naming convention; username@springfield
+# Find namespace via our naming convention; username@springfield.
+# TODO: Check that we're using a valid namespace.
 namespace="${context%%@springfield}"
 echo "Using namespace '${namespace}'..."
 
@@ -25,6 +26,7 @@ key="${HOME}/.ssh/${namespace}"
 dir="${HOME}/Springfield"
 
 # Find 'storage-proxy' SSH port.
+# TODO: Check that we found a service port.
 port="$(kubectl get svc -o jsonpath="{.items[?(@.metadata.name=='storage-proxy')]..nodePort}")"
 echo "Targeting SSH server on port ${port}"
 
@@ -49,6 +51,7 @@ fstab="/etc/fstab"
 
 # Create /etc/fstab entry.
 # <file system>  <mount point>  <type>  <options>  <dump>  <pass>
+# TODO: Check if fstab already contains a Springfield entry?
 entry="${fs}  ${dir}  fuse.sshfs $(join_by , "${opts[@]}")  0  0"
 echo "${entry}" | sudo tee -a "${fstab}" >> /dev/null
 

--- a/docs/configure-sshfs.sh
+++ b/docs/configure-sshfs.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# https://stackoverflow.com/a/17841619/57858
+function join_by { local IFS="$1"; shift; echo "$*"; }
+
+# Assumptions:
+#   1. sshfs is available.
+#   2. /etc/fuse.conf has `user_allow_other`.
+#   3. kubectl context is set to user's namespace.
+
+uid=$(id -u)
+gid=$(id -g)
+
+# Assume current context is set to Springfield.
+context="$(kubectl config current-context)"
+
+# Find namespace via our naming convention; username@springfield
+namespace="${context%%@springfield}"
+echo "Using namespace '${namespace}'..."
+
+fs="root@springfield.uit.no:/root"
+key="${HOME}/.ssh/${namespace}"
+dir="${HOME}/Springfield"
+
+# Find 'storage-proxy' SSH port.
+port="$(kubectl get svc -o jsonpath="{.items[?(@.metadata.name=='storage-proxy')]..nodePort}")"
+echo "Targeting SSH server on port ${port}"
+
+# Define mount options.
+opts=(
+  "_netdev"
+  "noauto"
+  "x-systemd.automount"
+  "reconnect"
+  "allow_other"
+  "user"
+  "follow_symlinks"
+  "idmap=user"
+  "identityfile=${key}"
+  "uid=${uid}"
+  "gid=${gid}"
+  "port=${port}"
+)
+
+# TODO: Locate this based on (common) system defaults?
+fstab="/etc/fstab"
+
+# Create /etc/fstab entry.
+# <file system>  <mount point>  <type>  <options>  <dump>  <pass>
+entry="${fs}  ${dir}  fuse.sshfs $(join_by , "${opts[@]}")  0  0"
+echo "${entry}" | sudo tee -a "${fstab}" >> /dev/null
+
+# TODO: Restart affected services (on common systems) automatically?
+# ...

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,23 +122,34 @@ curl https://uitml.github.io/springfield/prepare-authentication.sh | sh
 ```
 
 At this point we're almost ready to communicate with the storage proxy, but the
-container isn't normally accessible from outside the cluster network, so you'll
-have to use the port-forwarding support in `kubectl` to forward local network
-traffic to the cluster. Execute the command below to route traffic to port 2222
-on your computer to port 22 on the storage proxy container in the cluster. Note
-that this runs as a background process, and only works as long as that process
-is alive and healthy.
+container isn't accessible on the standard SSH port (22) because every user's
+namespace has a separate storage proxy. Because of this each storage proxy has
+been assigned a random port. You can find your storage proxy port number by
+running the command below.
 
 ```console
-kubectl port-forward deployments/storage-proxy 2222:22 >/dev/null 2>&1 &
+echo $(kubectl get svc -o jsonpath="{.items[?(@.metadata.name=='storage-proxy')]..nodePort}")
 ```
 
-Verify that everything is working by executing the command below, which should
-print some environment variables set inside the storage proxy container.
+Once you have your port number run the command below, which should print some
+environment variables set inside the storage proxy container.
 
 ```console
-ssh -p 2222 root@localhost printenv
+ssh -p <your port> root@localhost printenv
 ```
+
+Assuming that the command below executed properly and you saw some environment
+variables printed in your terminal, you're now ready to interact with your
+personal cloud file storage. You can use any tool you prefer that supports the
+SSH or SFTP protocols to transfer files, e.g. `scp` or `rsync`.
+
+### Setting up sshfs (recommended)
+
+If you want a more convenient workflow by mounting the cloud file storage as a
+network device, follow the instructions below, otherwise skip ahead to
+[_Running experiments_](#running-experiments).
+
+...
 
 ## Running experiments
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,7 +135,7 @@ Once you have your port number run the command below, which should print some
 environment variables set inside the storage proxy container.
 
 ```console
-ssh -p <your port> root@localhost printenv
+ssh -p <your port> root@springfield.uit.no printenv
 ```
 
 Assuming that the command below executed properly and you saw some environment


### PR DESCRIPTION
In order to improve end-user development workflow, sshfs can be used to mount the cloud file storage on Springfield on their local machine. This approach means that all files stored on Springfield can be viewed and edited using GUI applications and shells alike, circumventing the need to use `scp` and similar tools to keep local and remote file systems in sync.

This PR automates the configuration of sshfs via a shell script.

## TODO

- [ ] Document sshfs installation
  - [ ] GNU/Linux
  - [ ] macOS (https://osxfuse.github.io/)
  - [ ] Windows (https://www.nsoftware.com/sftp/drive/)
- [x] Ensure automation script works on Linux.
- [ ] Ensure automation script works on macOS.