### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,7 +135,7 @@ Once you have your port number run the command below, which should print some
 environment variables set inside the storage proxy container.
 
 ```console
-ssh -p <your port> root@localhost printenv
+ssh -p <your port> -o identityfile=<path/to/certificate> root@springfield.uit.no printenv
 ```
 
 Assuming that the command below executed properly and you saw some environment


### PR DESCRIPTION
On my mac
```console
ssh -p <port> root@localhost printenv
```
yielded `ssh: connect to host localhost port 32492: Connection refused`.

Similarly 
```console
ssh -p <port> root@springfield.uit.no printenv
```
yielded `root@springfield.uit.no: Permission denied (publickey,keyboard-interactive).`

The proposed change works. Tested on macOS v10.13.6